### PR TITLE
Fix when git hash can't be read from previous build

### DIFF
--- a/copr_builder/errors.py
+++ b/copr_builder/errors.py
@@ -17,3 +17,7 @@ class CoprBuilderAlreadyFailed(CoprBuilderError):
 
 class CoprBuilderConfigurationError(CoprBuilderError):
     pass
+
+
+class CoprBuilderBrokenGitHash(CoprBuilderError):
+    pass


### PR DESCRIPTION
This is happening when build is done manually or something else than copr builder. Just do a new build no matter what is the hash.