### PR TITLE
Revert "Change spec after srpm build is done"

### DIFF
--- a/copr_builder/copr_project.py
+++ b/copr_builder/copr_project.py
@@ -91,7 +91,6 @@ class CoprProject(object):
 
         # make srpm
         srpm = self.srpm_builder.build()
-        self.srpm_builder.update_spec()
         return srpm
 
     def _extract_version(self, version_str):

--- a/copr_builder/srpm_builder.py
+++ b/copr_builder/srpm_builder.py
@@ -20,7 +20,6 @@ class SRPMBuilder(object):
         self.project_data = project_data
 
         self._spec_file = None
-        self._spec_version = None
 
         if git_dir is None:
             self.git_repo = GitRepo(project_data[GIT_URL_CONF])
@@ -68,13 +67,6 @@ class SRPMBuilder(object):
 
     @spec_version.setter
     def spec_version(self, new_version):
-        ''' Set spec version
-
-        Will be used in the update_spec() method.
-        '''
-        self._spec_version = new_version
-
-    def update_spec(self):
         ''' Update version in spec file so the build number is always higher '''
 
         spec_file = self._locate_spec_file()
@@ -84,11 +76,11 @@ class SRPMBuilder(object):
         with open(spec_file, 'r') as f:
             for line in f:
                 if line.startswith('Version:'):
-                    new_spec.append('Version: %s\n' % self._spec_version.version)
+                    new_spec.append('Version: %s\n' % new_version.version)
                 elif line.startswith('Release:'):
-                    new_spec.append('Release: %s.%sgit%s%%{?dist}\n' % (self._spec_version.build,
-                                                                        self._spec_version.date,
-                                                                        self._spec_version.git_hash))
+                    new_spec.append('Release: %s.%sgit%s%%{?dist}\n' % (new_version.build,
+                                                                        new_version.date,
+                                                                        new_version.git_hash))
                 else:
                     new_spec.append(line)
 


### PR DESCRIPTION
We need to update the spec file before creating the SRPM because it needs to be built with the new version set.

Reverts vojtechtrefny/copr-builder#31