### PR TITLE
Avoid adding non tarballs as archives

### DIFF
--- a/copr_builder/srpm_builder.py
+++ b/copr_builder/srpm_builder.py
@@ -170,7 +170,7 @@ class SRPMBuilder(object):
             raise SRPMBuilderError('Failed to create source archive for %s:\n%s' % (self.project_data[PACKAGE_CONF], out))
 
         # archive should be created, get everything that looks like one
-        archives = [f for f in os.listdir(self.git_dir) if re.match(r'.*\.tar\.[gz|bz|bz2|xz]', f)]
+        archives = [f for f in os.listdir(self.git_dir) if re.match(r'.*\.tar\.(gz|bz|bz2|xz)$', f)]
         if not archives:
             raise SRPMBuilderError('Failed to find source archive after creating it.')
         if len(archives) > 1:


### PR DESCRIPTION
I'm dealing with project which also generates *.tar.gz.asc which is crashing copr_builder without this patch.

Also fix a bug that `[A|B]` works as it match one of the `A`, `|`, `B` characters not as OR statement.