### PR TITLE
Ignore merge commits when checking last commit

### DIFF
--- a/copr_builder/git_repo.py
+++ b/copr_builder/git_repo.py
@@ -29,7 +29,7 @@ class GitRepo(object):
         self.gitdir = self.tempdir.name + '/' + subdirs[0]
 
     def last_commit(self, short=True):
-        command = 'git log --pretty=format:\'%%%s\' -n 1' % 'h' if short else 'H'
+        command = 'git log --no-merges --pretty=format:\'%%%s\' -n 1' % 'h' if short else 'H'
         ret, out = run_command(command, self.gitdir)
         if ret != 0:
             raise GitError('Failed to get last commit hash for %s:\n%s' % (self.repo_url, out))


### PR DESCRIPTION
We allow merging branches during build which creates a new merge
commit which causes a new build even if there is no change
upstream (because there is always a new commit locally -- the
merge commit we created).