### PR TITLE
Fix getting last commit from the repo

### DIFF
--- a/copr_builder/git_repo.py
+++ b/copr_builder/git_repo.py
@@ -8,6 +8,10 @@ from .errors import GitError
 log = logging.getLogger("copr.builder")
 
 
+# username used for git merge
+GIT_USER = "CoprBuilderBot"
+
+
 class GitRepo(object):
 
     def __init__(self, repo_url):
@@ -29,7 +33,8 @@ class GitRepo(object):
         self.gitdir = self.tempdir.name + '/' + subdirs[0]
 
     def last_commit(self, short=True):
-        command = 'git log --perl-regexp --author=\'^((?!Jenkins).*)$\' --pretty=format:\'%%%s\' -n 1' % 'h' if short else 'H'
+        command = 'git log --perl-regexp --author=\'^((?!%s).*)$\' --pretty=format:\'%%%s\' -n 1' % ('h' if short else 'H',
+                                                                                                     GIT_USER)
         ret, out = run_command(command, self.gitdir)
         if ret != 0:
             raise GitError('Failed to get last commit hash for %s:\n%s' % (self.repo_url, out))
@@ -52,8 +57,8 @@ class GitRepo(object):
 
     def merge(self, branch):
         # we need to set username and email to make git happy before merging
-        command = 'git config user.email "jenkins@example.com" && '\
-                  'git config user.name "Jenkins"'
+        command = 'git config user.email "%s@example.com" && '\
+                  'git config user.name "%s"' % (GIT_USER.lower(), GIT_USER)
         ret, out = run_command(command, self.gitdir)
         if ret != 0:
             raise GitError('Failed to set username and email before merging.\n%s' % out)

--- a/copr_builder/git_repo.py
+++ b/copr_builder/git_repo.py
@@ -29,7 +29,7 @@ class GitRepo(object):
         self.gitdir = self.tempdir.name + '/' + subdirs[0]
 
     def last_commit(self, short=True):
-        command = 'git log --no-merges --pretty=format:\'%%%s\' -n 1' % 'h' if short else 'H'
+        command = 'git log --perl-regexp --author=\'^((?!Jenkins).*)$\' --pretty=format:\'%%%s\' -n 1' % 'h' if short else 'H'
         ret, out = run_command(command, self.gitdir)
         if ret != 0:
             raise GitError('Failed to get last commit hash for %s:\n%s' % (self.repo_url, out))


### PR DESCRIPTION
We have excluded merge commits for the log in df192c2 to avoid
using the 'artificial' merge commit produced during the build
process but sometimes a merge commit can be a valid last commit
in the repo we are trying to build so we need to exclude commits
based on the author instead. Our merge commits are commited by
'Jenkins' so it should be safe to exclude all commits based on
this.