### PR TITLE
Fix command for getting last commit

### DIFF
--- a/copr_builder/git_repo.py
+++ b/copr_builder/git_repo.py
@@ -33,8 +33,8 @@ class GitRepo(object):
         self.gitdir = self.tempdir.name + '/' + subdirs[0]
 
     def last_commit(self, short=True):
-        command = 'git log --perl-regexp --author=\'^((?!%s).*)$\' --pretty=format:\'%%%s\' -n 1' % ('h' if short else 'H',
-                                                                                                     GIT_USER)
+        command = 'git log --perl-regexp --author=\'^((?!%s).*)$\' ' \
+                  '--pretty=format:\'%%%s\' -n 1' % (GIT_USER, 'h' if short else 'H')
         ret, out = run_command(command, self.gitdir)
         if ret != 0:
             raise GitError('Failed to get last commit hash for %s:\n%s' % (self.repo_url, out))


### PR DESCRIPTION
Wrong order of arguments for the string builder when chaning the
commiter name in 3cf2e3449a628dc7f0b2aab1ca6691a521881dbf