### PR TITLE
Remove "W0142" (Used * or ** magic) from ignored pylint warnings

### DIFF
--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -19,8 +19,7 @@ class CoprBuilderSetupLintConfig(PocketLintConfig):
 
     @property
     def disabledOptions(self):
-        return ["W0142",           # Used * or ** magic
-                "W0511",           # Used when a warning note as FIXME or XXX is detected.
+        return ["W0511",           # Used when a warning note as FIXME or XXX is detected.
                 "I0011",           # Locally disabling %s
                 ]
 


### PR DESCRIPTION
The warning is deprecated since pylint 1.4.3 and was removed in
the latest release pylint so we get a warning when trying to
ignore it with --disable commandline option.