### PR TITLE
Check that we correctly parsed the SRPM name from rpmbuild output

### DIFF
--- a/copr_builder/srpm_builder.py
+++ b/copr_builder/srpm_builder.py
@@ -221,12 +221,16 @@ class SRPMBuilder(object):
         if ret != 0:
             raise SRPMBuilderError('SPRM generation failed:\n %s' % out)
 
+        srpm = None
         for line in out.split("\n"):
             # XXX: we assume there is only one line starting with "Wrote:"
             if line.startswith('Wrote:'):
                 srpm = line.split('Wrote:')[1].strip()
                 log.info('%s SRPM built for %s: %s', self._log_prefix, pkg_name, srpm)
                 break
+
+        if not srpm or not os.path.exists(srpm):
+            raise SRPMBuilderError('Cannot find the generated SRPM "%s"' % srpm)
 
         return srpm
 


### PR DESCRIPTION
Follow up for b79b0bac408009a0dc7a1e79f650180ef7ea947f, we want to
fail if we cannot get the SRPM name/path instead of waiting for
the next step to fail when trying to access an invalid path.