### PR TITLE
tests: Add a simple test case for SRPMBuilder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       run: |
         sudo apt-get -qq update
         sudo apt-get -qq install libkrb5-dev
+        sudo apt-get -qq install rpm
         python -m pip install --upgrade pip
         python -m pip install pylint pycodestyle pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi

--- a/tests/test_srpm_builder.py
+++ b/tests/test_srpm_builder.py
@@ -1,0 +1,29 @@
+import pytest
+import os
+import shutil
+
+from copr_builder import GIT_URL_CONF, PACKAGE_CONF, ARCHIVE_CMD_CONF, GIT_BRANCH_CONF
+from copr_builder.srpm_builder import SRPMBuilder
+
+
+def test_build_srpm():
+    if not shutil.which("rpmbuild"):
+        pytest.skip("rpmbuild not available")
+
+    # try to build copr-builder srpm from git
+    project_data = {GIT_URL_CONF: "https://github.com/vojtechtrefny/copr-builder",
+                    PACKAGE_CONF: "copr-builder",
+                    ARCHIVE_CMD_CONF: "make local",
+                    GIT_BRANCH_CONF: "master"}
+
+    srpm_builder = SRPMBuilder(project_data)
+    srpm_builder.prepare_build()
+    srpm_builder.make_archive()
+    srpm = srpm_builder.build()
+
+    assert srpm is not None
+    assert os.path.exists(srpm)
+
+    srpm_name = os.path.basename(srpm)
+    assert srpm_name.startswith("copr-builder")
+    assert srpm_name.endswith("src.rpm")


### PR DESCRIPTION
We now have a SPEC file for copr-builder so we can test the SRPM
build locally.