### PR TITLE
Use tarfile.is_tarfile to check for generated source archives

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ Config file structure
 - **pre_archive_cmd** -- *(optional)* command which will be run before the spec file is read. This can be used to generate or download the spec file.
 - **archive_cmd** -- command for creating an archive from the source (e.g. "make local" or "git archive HEAD --prefix=package/ -o package.tar.gz")
 
-  - this command must create at least one archive (*.tar.[gz|bz|bz2|xz]*) in the current directory
+  - this command must create at least one source archive in the current directory
 
 - **git_url** -- URL of the Git repo (will be used for "git clone")
 - **git_branch** -- branch to use from the Git repo (e.g. "master")

--- a/copr_builder/srpm_builder.py
+++ b/copr_builder/srpm_builder.py
@@ -2,6 +2,7 @@ import glob
 import logging
 import os
 import re
+import tarfile
 
 from . import GIT_URL_CONF, PACKAGE_CONF, PRE_ARCHIVE_CMD_CONF, ARCHIVE_CMD_CONF, GIT_BRANCH_CONF, \
     GIT_MERGE_BRANCH_CONF, CoprBuilderVersion
@@ -189,7 +190,8 @@ class SRPMBuilder(object):
             raise SRPMBuilderError('Failed to create source archive for %s:\n%s' % (self.project_data[PACKAGE_CONF], out))
 
         # archive should be created, get everything that looks like one
-        archives = [f for f in reversed(os.listdir(self.git_dir)) if re.match(r'.*\.tar\.(gz|bz|bz2|xz)$', f)]
+        paths = [os.path.join(self.git_dir, f) for f in os.listdir(self.git_dir)]
+        archives = [p for p in paths if (os.path.isfile(p) and tarfile.is_tarfile(p))]
         if not archives:
             raise SRPMBuilderError('Failed to find source archive after creating it.')
 


### PR DESCRIPTION
This should be more reliable than matching the file extensions.

Fixes: #66